### PR TITLE
fix: reading env for fresheyes bot events

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -373,26 +373,53 @@ pub async fn fetch_github_data(url: &str, method: RequestMethod, token: String) 
 pub fn extract_pr_details(data: &Value) -> PullRequestDetails {
     let base_sha = data["base"]["sha"].as_str().unwrap_or_default().to_string();
     let head_sha = data["head"]["sha"].as_str().unwrap_or_default().to_string();
-    let base_ref = format!(
-        "{}-fresheyes-{}-{}",
-        data["base"]["user"]["login"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string(),
-        data["base"]["ref"].as_str().unwrap_or_default().to_string(),
-        data["number"].as_u64().unwrap_or_default().to_string()
-    );
-    let head_ref = format!(
-        "{}-fresheyes-{}-{}",
-        data["head"]["user"]["login"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string(),
-        data["head"]["ref"].as_str().unwrap_or_default().to_string(),
-        data["number"].as_u64().unwrap_or_default().to_string()
-    );
     let title = data["title"].as_str().unwrap_or_default().to_string();
     let body = data["body"].as_str().unwrap_or_default().to_string();
+
+    let mut base_ref = String::new();
+    let mut head_ref = String::new();
+
+    if let Ok(environment) = std::env::var("ENV") {
+        if environment == "staging" {
+            base_ref = format!(
+                "{}-fresheyes-staging-{}-{}",
+                data["base"]["user"]["login"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                data["base"]["ref"].as_str().unwrap_or_default().to_string(),
+                data["number"].as_u64().unwrap_or_default().to_string()
+            );
+            head_ref = format!(
+                "{}-fresheyes-staging-{}-{}",
+                data["head"]["user"]["login"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                data["head"]["ref"].as_str().unwrap_or_default().to_string(),
+                data["number"].as_u64().unwrap_or_default().to_string()
+            );
+        } else {
+            base_ref = format!(
+                "{}-fresheyes-{}-{}",
+                data["base"]["user"]["login"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                data["base"]["ref"].as_str().unwrap_or_default().to_string(),
+                data["number"].as_u64().unwrap_or_default().to_string()
+            );
+            head_ref = format!(
+                "{}-fresheyes-{}-{}",
+                data["head"]["user"]["login"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                data["head"]["ref"].as_str().unwrap_or_default().to_string(),
+                data["number"].as_u64().unwrap_or_default().to_string()
+            );
+        }
+    }
 
     PullRequestDetails {
         base_sha,

--- a/client/fresheyes-bot/src/index.ts
+++ b/client/fresheyes-bot/src/index.ts
@@ -2,41 +2,68 @@ import { Probot } from "probot";
 import { generateBody, groupCommentsFn } from "./util";
 
 export = (robot: Probot) => {
-  const staging = process.env.BOT_ENV ?? ""
+  const staging = process.env.BOT_ENV ?? "";
   robot.on(["pull_request.opened"], async (context) => {
     /**  Get information about the pull request **/
-    const { owner: forked_owner, repo: forked_repo, pull_number: forked_pull_number } = context.pullRequest();
-    const { label, ref, repo: { default_branch} } = context.payload.pull_request.base;
+    const {
+      owner: forked_owner,
+      repo: forked_repo,
+      pull_number: forked_pull_number,
+    } = context.pullRequest();
+    const {
+      label,
+      ref,
+      repo: { default_branch },
+    } = context.payload.pull_request.base;
     const branch_name = ref.split("-").slice(0, 3).join("-");
-    const shouldRun = branch_name === `${forked_repo}-fresheyes-${staging ? "staging" : default_branch}`;
+    const shouldRun =
+      branch_name ===
+      `${forked_repo}-fresheyes-${staging ? "staging" : default_branch}`;
     if (!shouldRun) {
       robot.log("Branch is not the correct branch");
       return;
     }
-    
-    const res = await context.octokit.repos.get({ owner: forked_owner, repo: forked_repo });
+
+    const res = await context.octokit.repos.get({
+      owner: forked_owner,
+      repo: forked_repo,
+    });
 
     const owner = res.data.parent?.owner.login;
     const repo = res.data.parent?.name;
     const pull_number = Number(label.split("-").slice(-1));
 
     if (!owner || !repo || !pull_number) {
-      throw Error(`Could not get parent repo information ${owner} ${repo} ${pull_number}`);
+      throw Error(
+        `Could not get parent repo information ${owner} ${repo} ${pull_number}`
+      );
     }
 
-    const { data } = await context.octokit.pulls.listReviewComments({ owner, repo, pull_number });
+    const { data } = await context.octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number,
+    });
 
     try {
       if (!data || data.length === 0) {
         return;
       }
 
-      const groupComments: Record<string, Array<typeof data>> = groupCommentsFn(data);
+      const groupComments: Record<string, Array<typeof data>> = groupCommentsFn(
+        data
+      );
 
       await Promise.all(
         Object.entries(groupComments).map(async ([key, value]) => {
           const { body, comment } = generateBody(value);
 
+          if (!key) {
+            // if key is undefined, we should not process this data
+            // but we should not throw an error
+            // continue to the next iteration
+            return;
+          }
           const res = await context.octokit.pulls.createReviewComment({
             owner: forked_owner,
             repo: forked_repo,


### PR DESCRIPTION
This PR push to fix an error where the fresheyes bot for staging and prod comments/dispatch on the repo install they are installed in, we are using this to track where a PR is been pushed so the appropriate bot can trigger.