### PR TITLE
Fix: 422 error when adding comments

### DIFF
--- a/client/fresheyes-bot/src/index.ts
+++ b/client/fresheyes-bot/src/index.ts
@@ -1,81 +1,70 @@
 import { Probot } from "probot";
-import { generateBody, groupCommentsFn } from "./util";
+import { extractData } from "./util";
 
 export = (robot: Probot) => {
   const staging = process.env.BOT_ENV ?? "";
+
   robot.on(["pull_request.opened"], async (context) => {
     /**  Get information about the pull request **/
-    const {
-      owner: forked_owner,
-      repo: forked_repo,
-      pull_number: forked_pull_number,
-    } = context.pullRequest();
+    const { owner: forked_owner, repo: forked_repo, pull_number: forked_pull_number } = context.pullRequest();
     const {
       label,
       ref,
       repo: { default_branch },
     } = context.payload.pull_request.base;
+
     const branch_name = ref.split("-").slice(0, 3).join("-");
-    const shouldRun =
-      branch_name ===
-      `${forked_repo}-fresheyes-${staging ? "staging" : default_branch}`;
+    const shouldRun = branch_name === `${forked_repo}-fresheyes-${staging ? "staging" : default_branch}`;
     if (!shouldRun) {
       robot.log("Branch is not the correct branch");
       return;
     }
 
-    const res = await context.octokit.repos.get({
-      owner: forked_owner,
-      repo: forked_repo,
-    });
+    const res = await context.octokit.repos.get({ owner: forked_owner, repo: forked_repo });
 
     const owner = res.data.parent?.owner.login;
     const repo = res.data.parent?.name;
     const pull_number = Number(label.split("-").slice(-1));
 
     if (!owner || !repo || !pull_number) {
-      throw Error(
-        `Could not get parent repo information ${owner} ${repo} ${pull_number}`
-      );
+      throw Error(`Could not get parent repo information ${owner} ${repo} ${pull_number}`);
     }
 
-    const { data } = await context.octokit.pulls.listReviewComments({
-      owner,
-      repo,
-      pull_number,
-    });
+    const { data: reviewComments } = await context.octokit.pulls.listReviewComments({ owner, repo, pull_number });
+
+    const { data: issueComments } = await context.octokit.issues.listComments({ owner, repo, issue_number: pull_number });
 
     try {
-      if (!data || data.length === 0) {
+      if (!reviewComments && !issueComments) {
         return;
       }
 
-      const groupComments: Record<string, Array<typeof data>> = groupCommentsFn(
-        data
-      );
+      const { allComments } = extractData(reviewComments, issueComments);
 
       await Promise.all(
-        Object.entries(groupComments).map(async ([key, value]) => {
-          const { body, comment } = generateBody(value);
-
-          if (!key) {
-            // if key is undefined, we should not process this data
-            // but we should not throw an error
-            // continue to the next iteration
+        allComments.map(async (val) => {
+          /** Create comments according to the time they were added **/
+          if (val.key === "review") {
+            await context.octokit.pulls.createReviewComment({
+              owner: forked_owner,
+              repo: forked_repo,
+              pull_number: forked_pull_number,
+              body: val.body,
+              commit_id: val.commit_id,
+              path: val.path,
+              side: val.side,
+              line: Number(val.line),
+            });
+          } else if (val.key === "issue") {
+            await context.octokit.issues.createComment({
+              owner: forked_owner,
+              repo: forked_repo,
+              issue_number: forked_pull_number,
+              body: val.body,
+            });
+          } else {
             return;
           }
-          const res = await context.octokit.pulls.createReviewComment({
-            owner: forked_owner,
-            repo: forked_repo,
-            pull_number: forked_pull_number,
-            body: body,
-            commit_id: comment.commit_id,
-            path: comment.path,
-            side: comment.side,
-            line: Number(key),
-          });
-
-          return res;
         })
       );
     } catch (error) {

--- a/client/fresheyes-bot/src/util.ts
+++ b/client/fresheyes-bot/src/util.ts
@@ -55,7 +55,7 @@ export function getReviewBody<T extends Array<Array<Record<string, any>>>>(value
     })
     .join("\n");
 
-  const body = `${value.length === 1 ? "An author" : `${value.length} authors`} commented here with\n\n${formatString}.`;
+  const body = `${value.length === 1 ? "An author" : `${value.length} authors`} commented here with:\n\n${formatString}.`;
 
   const comment = value.flat().sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())[0];
 
@@ -65,7 +65,7 @@ export function getReviewBody<T extends Array<Array<Record<string, any>>>>(value
 export function getIssueBody<T extends Pick<T, "html_url" | "created_at">>(arg: T, idx: number) {
   const formatString = `- [comment link ${idx + 1}](${arg.html_url}) at ${formatTime(arg.created_at as string)}`;
 
-  const body = `An author commented here with\n\n${formatString}.`;
+  const body = `An author commented here with:\n\n${formatString}.`;
 
   return { body };
 }

--- a/client/fresheyes-bot/src/util.ts
+++ b/client/fresheyes-bot/src/util.ts
@@ -23,13 +23,18 @@ export function groupCommentsFn<T extends Array<Record<string, any>>>(data: T) {
   return comments;
 }
 
-const formatTime = (arg: string) => {
-  const [, year, month, day, hour, minute, second] = arg.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/) as RegExpMatchArray;
+function formatTime(arg: string) {
+  const date = new Date(arg);
 
-  const date = `${year}/${month}/${day}, ${hour}:${minute}:${second}`;
+  const year = date.getUTCFullYear();
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = date.getUTCDate().toString().padStart(2, "0");
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  const seconds = date.getUTCSeconds().toString().padStart(2, "0");
 
-  return date;
-};
+  return `${year}/${month}/${day}, ${hours}:${minutes}:${seconds} UTC`;
+}
 
 export const modifyPullRequestBody = (
   args: string | null

--- a/client/fresheyes-bot/src/util.ts
+++ b/client/fresheyes-bot/src/util.ts
@@ -1,5 +1,16 @@
+type Comment = {
+  body: string;
+  commit_id?: string;
+  path?: string;
+  side?: "LEFT" | "RIGHT" | undefined;
+  line?: number;
+  created_at: string;
+  key: string;
+};
+
 export function groupCommentsFn<T extends Array<Record<string, any>>>(data: T) {
   const comments: Record<string, Array<typeof data>> = data
+    .filter((f) => f.line !== null)
     .map((x: any) => ({ ...x, line: String(x.line) }))
     .reduce((acc, curr) => {
       const key = curr.line;
@@ -12,7 +23,7 @@ export function groupCommentsFn<T extends Array<Record<string, any>>>(data: T) {
   return comments;
 }
 
-export function generateBody<T extends Array<Array<Record<string, any>>>>(value: T) {
+export function getReviewBody<T extends Array<Array<Record<string, any>>>>(value: T) {
   const list = value.flat().map((x) => ({ html_url: x.html_url, created_at: x.created_at }));
 
   const formatString = list
@@ -22,7 +33,52 @@ export function generateBody<T extends Array<Array<Record<string, any>>>>(value:
     .join("\n");
 
   const body = `${value.length === 1 ? "An author" : `${value.length} authors`} commented here with\n\n${formatString}.`;
-  const comment = value.flat()[0];
+
+  const comment = value.flat().sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())[0];
 
   return { body, comment };
+}
+
+export function getIssueBody<T extends Pick<T, "html_url" | "created_at">>(arg: T, idx: number) {
+  const formatString = `- [comment link ${idx + 1}](${arg.html_url}) at ${new Date(arg.created_at as string | Date).toLocaleString()}`;
+
+  const body = `An author commented here with\n\n${formatString}.`;
+
+  return { body };
+}
+
+export function extractData<R extends Array<Record<string, any>>, I extends Array<Pick<Record<string, any>, "html_url" | "created_at">>>(
+  reviews: R,
+  issues: I
+) {
+  const groupReviews = groupCommentsFn(reviews);
+
+  const extract_reviews = Object.entries(groupReviews).map(([key, value]) => {
+    const { body, comment } = getReviewBody(value);
+
+    return {
+      body: body,
+      commit_id: comment.commit_id,
+      path: comment.path,
+      side: comment.side,
+      line: Number(key),
+      created_at: comment.created_at,
+      key: "review",
+    };
+  });
+
+  const extract_issues = issues.map((i, idx) => {
+    const { body } = getIssueBody(i, idx);
+    return {
+      body,
+      created_at: i.created_at,
+      key: "issue",
+    };
+  });
+
+  const allComments: Comment[] = [...extract_reviews, ...extract_issues].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  return { allComments };
 }

--- a/client/fresheyes-bot/src/util.ts
+++ b/client/fresheyes-bot/src/util.ts
@@ -23,12 +23,35 @@ export function groupCommentsFn<T extends Array<Record<string, any>>>(data: T) {
   return comments;
 }
 
+const formatTime = (arg: string) => {
+  const [, year, month, day, hour, minute, second] = arg.match(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/) as RegExpMatchArray;
+
+  const date = `${year}/${month}/${day}, ${hour}:${minute}:${second}`;
+
+  return date;
+};
+
+export const modifyPullRequestBody = (
+  args: string | null
+): {
+  body: string;
+} => {
+  if (!args) return { body: "" };
+
+  const body = args
+    .split(" ")
+    .map((word) => (word.startsWith("#") || word.startsWith("@") ? "`" + word.trim() + "`" : word))
+    .join(" ");
+
+  return { body };
+};
+
 export function getReviewBody<T extends Array<Array<Record<string, any>>>>(value: T) {
   const list = value.flat().map((x) => ({ html_url: x.html_url, created_at: x.created_at }));
 
   const formatString = list
     .map((val, idx) => {
-      return `- [comment link ${idx + 1}](${val.html_url}) at ${new Date(val.created_at).toLocaleString()}`;
+      return `- [comment link ${idx + 1}](${val.html_url}) at ${formatTime(val.created_at)}`;
     })
     .join("\n");
 
@@ -40,7 +63,7 @@ export function getReviewBody<T extends Array<Array<Record<string, any>>>>(value
 }
 
 export function getIssueBody<T extends Pick<T, "html_url" | "created_at">>(arg: T, idx: number) {
-  const formatString = `- [comment link ${idx + 1}](${arg.html_url}) at ${new Date(arg.created_at as string | Date).toLocaleString()}`;
+  const formatString = `- [comment link ${idx + 1}](${arg.html_url}) at ${formatTime(arg.created_at as string)}`;
 
   const body = `An author commented here with\n\n${formatString}.`;
 


### PR DESCRIPTION
This pr fixes the 422 error when creating comments and introduces addition of issue comments by the fresheyes bot

- Modify dataset fetching to remove comments with null values in their line key, this fixes the 422 error when creating comments 
- Add issue comments; the fresheyes-bot now adds review comments and issue comments
- Add  comments in the order they were created